### PR TITLE
feat: Enhance campaign management, editing, and publishing options

### DIFF
--- a/compose.php
+++ b/compose.php
@@ -1,113 +1,238 @@
 <?php
 require_once 'includes/functions.php'; // This handles DB connection and loads $APP_SETTINGS
-require_once 'includes/compose_functions.php'; // For save_campaign_to_db, get_all_templates_for_compose, get_template_content_for_compose
+require_once 'includes/compose_functions.php'; // For campaign functions
 
-$all_templates = [];
-$error_message = '';
-$success_message = '';
+global $conn; // Ensure $conn is in scope
+global $APP_SETTINGS; // Ensure $APP_SETTINGS is in scope
 
-// Form field values - prefill if available (e.g. from loaded template or POST error)
-$campaign_name = $_POST['campaign_name'] ?? '';
-$subject = $_POST['subject'] ?? '';
-$body_html = $_POST['body_html'] ?? '';
-$selected_template_id = $_POST['template_id'] ?? '';
-$schedule_send = isset($_POST['schedule_send']);
-$scheduled_at_value = $_POST['scheduled_at'] ?? '';
+$page_error_message = ''; // Renamed from $error_message to avoid conflicts if any other include uses it
+$page_success_message = ''; // Renamed from $success_message
 
+// Form field values - prefill if available
+$campaign_name = '';
+$subject = '';
+$body_html = '';
+$selected_template_id = ''; // Template selection might be disabled or handled differently in edit mode
+$schedule_send = false;
+$scheduled_at_value = '';
+$current_campaign_status = ''; // To store the status of the campaign being edited
 
-if (!isset($conn) || $conn === null) {
-    $error_message = "Database connection failed. Please check configuration.";
-} else {
-    $all_templates = get_all_templates_for_compose($conn);
+// Edit mode variables
+$edit_mode = false;
+$campaign_id_to_edit = null;
+$page_title = "Compose New Campaign"; // Default page title
 
-    // If a template is selected to be loaded via GET (and not a POST request which might have data)
-    if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['load_template_id'])) {
-        $selected_template_id = $_GET['load_template_id'];
-        if (!empty($selected_template_id)) {
-            $template_content = get_template_content_for_compose($conn, $selected_template_id);
-            if ($template_content) {
-                $subject = $template_content['subject']; // Prefill subject
-                $body_html = $template_content['body_html']; // Prefill body
-                // Campaign name might also be prefilled based on template, e.g.
-                // $campaign_name = "Campaign for " . $template_content['name']; // Assuming template name is available
+// Check for edit mode (GET request)
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['edit_campaign_id'])) {
+    if (!empty($_GET['edit_campaign_id']) && is_numeric($_GET['edit_campaign_id'])) {
+        $campaign_id_to_edit = (int)$_GET['edit_campaign_id'];
+
+        if (isset($conn) && $conn instanceof mysqli && $conn->ping()) { // Check $conn validity
+            $campaign_data = get_campaign_by_id($conn, $campaign_id_to_edit);
+            if ($campaign_data) {
+                $edit_mode = true;
+                $page_title = "Edit Campaign: " . htmlspecialchars($campaign_data['name']);
+
+                // Pre-fill form variables from fetched campaign data
+                $campaign_name = $campaign_data['name'];
+                $subject = $campaign_data['subject'];
+                $body_html = $campaign_data['body_html'];
+                $current_campaign_status = $campaign_data['status']; // Store current status
+
+                if ($campaign_data['status'] === 'scheduled' && !empty($campaign_data['scheduled_at'])) {
+                    $schedule_send = true;
+                    // Format for datetime-local input: YYYY-MM-DDTHH:MM
+                    try {
+                        $dt = new DateTime($campaign_data['scheduled_at']);
+                        $scheduled_at_value = $dt->format('Y-m-d\TH:i');
+                    } catch (Exception $e) {
+                        $scheduled_at_value = '';
+                        $page_error_message .= " Error parsing scheduled date for editing. ";
+                    }
+                } else {
+                    $schedule_send = false;
+                    $scheduled_at_value = '';
+                }
             } else {
-                $error_message = "Could not load selected template.";
-                // Clear selected_template_id if it's invalid to prevent form from showing it as selected
-                $selected_template_id = '';
+                $page_error_message = "Campaign not found for editing (ID: " . htmlspecialchars($campaign_id_to_edit) . ").";
+                $campaign_id_to_edit = null;
+            }
+        } else {
+            $page_error_message = "Database connection error. Cannot load campaign for editing.";
+            $campaign_id_to_edit = null;
+        }
+    } else {
+        $page_error_message = "Invalid campaign ID for editing.";
+    }
+}
+
+// Handle POST request (create or update)
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
+    // Retrieve all form fields from POST to repopulate form if error or for saving
+    $campaign_name = trim($_POST['campaign_name'] ?? '');
+    $subject = trim($_POST['subject'] ?? '');
+    $body_html = trim($_POST['body_html'] ?? '');
+    $selected_template_id = $_POST['template_id'] ?? '';
+    $schedule_send = isset($_POST['schedule_send']);
+    $scheduled_at_value = $_POST['scheduled_at'] ?? '';
+    $action = $_POST['action'];
+
+    // Determine if we are in edit mode for this POST submission
+    $campaign_id_for_saving = null;
+    if (isset($_POST['campaign_id']) && is_numeric($_POST['campaign_id']) && $_POST['campaign_id'] > 0) {
+        $campaign_id_for_saving = (int)$_POST['campaign_id'];
+        $edit_mode = true;
+        $campaign_id_to_edit = $campaign_id_for_saving; // Ensure $campaign_id_to_edit is set for POST context
+         // Update page title for edit mode if it wasn't set by GET (e.g. POST error on edit)
+        if ($page_title === "Compose New Campaign" || strpos($page_title, (string)$campaign_id_for_saving) === false) {
+            $temp_campaign_name_for_title = !empty($campaign_name) ? $campaign_name : null;
+            if (empty($temp_campaign_name_for_title) && isset($conn) && $conn instanceof mysqli && $conn->ping()){
+                 $temp_data = get_campaign_by_id($conn, $campaign_id_for_saving);
+                 if($temp_data) $temp_campaign_name_for_title = $temp_data['name'];
+            }
+            $page_title = "Edit Campaign: " . (!empty($temp_campaign_name_for_title) ? htmlspecialchars($temp_campaign_name_for_title) : "ID " . htmlspecialchars($campaign_id_for_saving));
+        }
+    } else {
+        $edit_mode = false;
+    }
+
+    $status = 'draft';
+    $scheduled_at_for_db = null;
+
+    if ($action === 'save_draft') {
+        $status = 'draft';
+    } elseif ($action === 'schedule_campaign') {
+        if (!$schedule_send || empty($scheduled_at_value)) {
+            $page_error_message = "To schedule a campaign, please check 'Schedule Send' and select a date and time.";
+        } else {
+            $status = 'scheduled';
+            $scheduled_at_for_db = $scheduled_at_value;
+        }
+    } elseif ($action === 'send_now') {
+        $status = 'sent';
+    }
+
+    if (empty($page_error_message)) {
+        if (empty($campaign_name) || empty($subject) || empty($body_html)) {
+            $page_error_message = "Campaign Name, Subject, and Email Body are required.";
+        } else {
+            $save_result_mixed = save_campaign_to_db(
+                $conn,
+                $campaign_name,
+                $subject,
+                $body_html,
+                $status,
+                $scheduled_at_for_db,
+                $campaign_id_for_saving // Pass the ID if we are editing
+            );
+
+            if (is_numeric($save_result_mixed) && $save_result_mixed > 0) {
+                $returned_campaign_id = (int)$save_result_mixed;
+                $action_verb = '';
+
+                if ($edit_mode) {
+                    if ($returned_campaign_id === $campaign_id_for_saving) {
+                        $action_verb = 'updated';
+                    } else {
+                        $action_verb = 'processed (unexpected ID)';
+                    }
+                } else {
+                    $action_verb = 'created';
+                }
+
+                // Refine action_verb based on status for more specific feedback
+                if ($status === 'sent' && $action_verb !== 'processed (unexpected ID)') $action_verb = 'sent';
+                else if ($status === 'scheduled' && $action_verb !== 'processed (unexpected ID)') $action_verb = 'scheduled';
+                // If 'draft', it will use 'created' or 'updated' which is fine.
+
+                $page_success_message = "Campaign '" . htmlspecialchars($campaign_name) . "' " . $action_verb . " successfully (ID: " . $returned_campaign_id . ")!";
+
+                if (!$edit_mode) { // New campaign successfully created
+                    $campaign_name = $subject = $body_html = $selected_template_id = $scheduled_at_value = '';
+                    $schedule_send = false;
+                } else { // Existing campaign successfully updated
+                    // Re-load data for the current campaign to show updated values
+                    $campaign_data_reloaded = get_campaign_by_id($conn, $returned_campaign_id);
+                    if ($campaign_data_reloaded) {
+                        // $campaign_name, $subject, $body_html are already from $_POST (latest submission)
+                        // Update status and schedule related fields from what's now in DB
+                        $current_campaign_status = $campaign_data_reloaded['status'];
+                        if ($campaign_data_reloaded['status'] === 'scheduled' && !empty($campaign_data_reloaded['scheduled_at'])) {
+                            $schedule_send = true;
+                            try {
+                                $dt = new DateTime($campaign_data_reloaded['scheduled_at']);
+                                $scheduled_at_value = $dt->format('Y-m-d\TH:i');
+                            } catch (Exception $e) { $scheduled_at_value = ''; }
+                        } else {
+                            $schedule_send = false;
+                            $scheduled_at_value = '';
+                        }
+                        // Update page title again in case name changed during update
+                        $page_title = "Edit Campaign: " . htmlspecialchars($campaign_data_reloaded['name']);
+                    }
+                }
+            } else {
+                $page_error_message = is_string($save_result_mixed) ? $save_result_mixed : "Failed to save/update campaign due to an unknown error.";
             }
         }
     }
-
-    // Handle POST request to save campaign
-    if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action'])) {
-        $action = $_POST['action'];
-
-        // Values are already pre-filled from $_POST at the top
-        // $campaign_name = trim($_POST['campaign_name'] ?? '');
-        // $subject = trim($_POST['subject'] ?? '');
-        // $body_html = trim($_POST['body_html'] ?? '');
-        // $selected_template_id = $_POST['template_id'] ?? '';
-        // $schedule_send = isset($_POST['schedule_send']);
-        // $scheduled_at_value = $_POST['scheduled_at'] ?? '';
-
-        $status = 'draft'; // Default status
-        $scheduled_at_for_db = null;
-
-        if ($action === 'save_draft') {
-            $status = 'draft';
-        } elseif ($action === 'schedule_campaign') {
-            if (!$schedule_send || empty($scheduled_at_value)) {
-                $error_message = "To schedule a campaign, please check 'Schedule Send' and select a date and time.";
-            } else {
-                $status = 'scheduled';
-                $scheduled_at_for_db = $scheduled_at_value;
-            }
-        }
-        // Add other actions like 'send_now' if needed
-
-        if (empty($error_message)) { // Proceed if no scheduling error
-            if (empty($campaign_name) || empty($subject) || empty($body_html)) {
-                $error_message = "Campaign Name, Subject, and Email Body are required.";
-            } else {
-                $save_result = save_campaign_to_db($conn, $campaign_name, $subject, $body_html, $status, $scheduled_at_for_db);
-                if ($save_result === true) {
-                    $success_message = "Campaign '" . htmlspecialchars($campaign_name) . "' saved successfully as " . htmlspecialchars($status) . "!";
-                    // Clear form fields after successful save
-                    $campaign_name = $subject = $body_html = $selected_template_id = $scheduled_at_value = '';
-                    $schedule_send = false;
-                } else {
-                    $error_message = is_string($save_result) ? $save_result : "Failed to save campaign.";
-                }
-            }
+} elseif ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    // Fallback for non-GET, non-action POST (e.g. if JS disabled and form submitted unexpectedly)
+    // Repopulate form from whatever was POSTed to maintain user input.
+    $campaign_name = trim($_POST['campaign_name'] ?? $campaign_name);
+    $subject = trim($_POST['subject'] ?? $subject);
+    $body_html = trim($_POST['body_html'] ?? $body_html);
+    $selected_template_id = $_POST['template_id'] ?? $selected_template_id;
+    $schedule_send = isset($_POST['schedule_send']) ? true : $schedule_send; // Keep submitted state
+    $scheduled_at_value = $_POST['scheduled_at'] ?? $scheduled_at_value; // Keep submitted state
+    // If campaign_id was in POST, ensure edit mode is still considered
+    if(isset($_POST['campaign_id']) && is_numeric($_POST['campaign_id'])) {
+        $campaign_id_to_edit = (int)$_POST['campaign_id'];
+        $edit_mode = true;
+        if ($page_title === "Compose New Campaign") { // Update title if needed
+             $page_title = "Edit Campaign (ID: " . htmlspecialchars($campaign_id_to_edit) . ")";
         }
     }
 }
+
+
+// Fetch all templates for the dropdown, regardless of mode (new/edit)
+// This should be done after any potential DB connection check
+if (isset($conn) && $conn instanceof mysqli && $conn->ping() && empty($page_error_message)) { // Check $conn and avoid if previous error
+    $all_templates = get_all_templates_for_compose($conn);
+} elseif (!isset($conn) || !$conn instanceof mysqli || !$conn->ping()) {
+    if(empty($page_error_message)) $page_error_message = "Database connection failed. Cannot load templates.";
+}
+
 ?>
 <?php include 'includes/header.php'; ?>
 <?php include 'includes/sidebar.php'; ?>
 
 <main class="col-md-9 ms-sm-auto col-lg-10 px-md-4">
     <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
-        <h1 class="h2">Compose New Campaign</h1>
+        <h1 class="h2"><?php echo $page_title; ?></h1>
     </div>
 
-    <?php if (!empty($success_message)): ?>
+    <?php if (!empty($page_success_message)): ?>
         <div class="alert alert-success alert-dismissible fade show" role="alert">
-            <?php echo htmlspecialchars($success_message); ?>
+            <?php echo htmlspecialchars($page_success_message); ?>
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
     <?php endif; ?>
-    <?php if (!empty($error_message)): ?>
+    <?php if (!empty($page_error_message)): ?>
         <div class="alert alert-danger alert-dismissible fade show" role="alert">
-            <?php echo htmlspecialchars($error_message); ?>
+            <?php echo $page_error_message; // May contain HTML like <br> from multiple errors ?>
             <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
         </div>
     <?php endif; ?>
 
-    <?php if (!isset($conn) || $conn === null): ?>
+    <?php if (!isset($conn) || !$conn instanceof mysqli || !$conn->ping() && empty($page_error_message)): // If $conn error but $page_error_message already shown, don't repeat generic DB error ?>
         <div class="alert alert-danger">Database connection is not available. Cannot load or save campaigns.</div>
     <?php else: ?>
-    <form id="composeForm" method="POST" action="compose.php">
+    <form id="composeForm" method="POST" action="compose.php<?php echo $edit_mode ? '?edit_campaign_id=' . htmlspecialchars($campaign_id_to_edit) : ''; ?>">
+        <?php if ($edit_mode && !empty($campaign_id_to_edit)): ?>
+            <input type="hidden" name="campaign_id" value="<?php echo htmlspecialchars($campaign_id_to_edit); ?>">
+        <?php endif; ?>
         <div class="row">
             <div class="col-md-8">
                 <div class="mb-3">
@@ -120,7 +245,7 @@ if (!isset($conn) || $conn === null) {
                 </div>
                 <div class="mb-3">
                     <label for="template_id" class="form-label">Load from Template</label>
-                    <select class="form-select" id="template_id" name="template_id">
+                    <select class="form-select" id="template_id" name="template_id" <?php if ($edit_mode && $current_campaign_status !== 'draft') echo 'disabled'; ?>>
                         <option value="">-- Select a Template --</option>
                         <?php if (!empty($all_templates)): ?>
                             <?php foreach ($all_templates as $template): ?>
@@ -130,29 +255,47 @@ if (!isset($conn) || $conn === null) {
                             <?php endforeach; ?>
                         <?php endif; ?>
                     </select>
+                     <?php if ($edit_mode && $current_campaign_status !== 'draft'): ?>
+                        <small class="form-text text-muted">Template selection is disabled for campaigns that are not drafts. Body can be edited directly.</small>
+                    <?php endif; ?>
                 </div>
                 <div class="mb-3">
                     <label for="body_html" class="form-label">Email Body</label>
-                    <textarea class="form-control" id="body_html" name="body_html" rows="15" required><?php echo htmlspecialchars($body_html); ?></textarea>
+                    <textarea class="form-control" id="body_html" name="body_html" rows="15" required <?php if ($edit_mode && $current_campaign_status === 'sent') echo 'readonly'; ?>><?php echo htmlspecialchars($body_html); ?></textarea>
+                     <?php if ($edit_mode && $current_campaign_status === 'sent'): ?>
+                        <small class="form-text text-muted">Body of a sent campaign cannot be edited.</small>
+                    <?php endif; ?>
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="card">
                     <div class="card-header"><h5>Actions & Options</h5></div>
                     <div class="card-body">
-                        <div class="form-check form-switch mb-3">
-                            <input class="form-check-input" type="checkbox" id="schedule_send_checkbox" name="schedule_send" <?php echo $schedule_send ? 'checked' : ''; ?>>
+                        <?php if ($edit_mode): ?>
+                             <p><strong>Status:</strong> <span class="badge bg-info"><?php echo htmlspecialchars(ucfirst($current_campaign_status)); ?></span></p>
+                             <?php if ($current_campaign_status === 'sent'): ?>
+                                <p class="text-muted"><small>This campaign has already been sent. Most fields cannot be modified. You might consider cloning it to a new campaign if changes are needed.</small></p>
+                             <?php endif; ?>
+                        <?php endif; ?>
+
+                        <div class="form-check form-switch mb-3" <?php if ($edit_mode && $current_campaign_status === 'sent') echo 'style="display:none;"'; ?>>
+                            <input class="form-check-input" type="checkbox" id="schedule_send_checkbox" name="schedule_send" <?php echo $schedule_send ? 'checked' : ''; ?> <?php if ($edit_mode && $current_campaign_status === 'sent') echo 'disabled'; ?>>
                             <label class="form-check-label" for="schedule_send_checkbox">Schedule Send</label>
                         </div>
-                        <div class="mb-3" id="schedule_options" style="<?php echo $schedule_send ? '' : 'display: none;'; ?>">
+                        <div class="mb-3" id="schedule_options" style="<?php echo $schedule_send ? '' : 'display: none;'; ?> <?php if ($edit_mode && $current_campaign_status === 'sent') echo 'display:none;'; ?>">
                             <label for="scheduled_at" class="form-label">Schedule Date & Time</label>
-                            <input type="datetime-local" class="form-control" id="scheduled_at" name="scheduled_at" value="<?php echo htmlspecialchars($scheduled_at_value); ?>">
+                            <input type="datetime-local" class="form-control" id="scheduled_at" name="scheduled_at" value="<?php echo htmlspecialchars($scheduled_at_value); ?>" <?php if ($edit_mode && $current_campaign_status === 'sent') echo 'disabled'; ?>>
                         </div>
-                        <hr>
+                        <hr <?php if ($edit_mode && $current_campaign_status === 'sent') echo 'style="display:none;"'; ?>>
                         <div class="d-grid gap-2">
-                            <button type="submit" name="action" value="save_draft" class="btn btn-secondary"><i class="fas fa-save"></i> Save Draft</button>
-                            <button type="submit" name="action" value="schedule_campaign" class="btn btn-primary"><i class="fas fa-clock"></i> Schedule Campaign</button>
-                            <!-- <button type="submit" name="action" value="send_now" class="btn btn-success"><i class="fas fa-paper-plane"></i> Send Now</button> -->
+                            <?php if (!$edit_mode || ($edit_mode && $current_campaign_status !== 'sent')): ?>
+                                <button type="submit" name="action" value="send_now" class="btn btn-success mb-2" <?php if ($edit_mode && $current_campaign_status === 'scheduled') echo 'disabled'; /* Maybe allow re-scheduling or unscheduling first */ ?>><i class="fas fa-paper-plane"></i> <?php echo $edit_mode ? 'Send Now (if not already sent)' : 'Send Immediately'; ?></button>
+                                <button type="submit" name="action" value="schedule_campaign" class="btn btn-primary mb-2"><i class="fas fa-clock"></i> <?php echo ($edit_mode && $current_campaign_status === 'scheduled') ? 'Update Schedule' : 'Save and Schedule'; ?></button>
+                                <button type="submit" name="action" value="save_draft" class="btn btn-secondary"><i class="fas fa-save"></i> <?php echo $edit_mode ? 'Save Changes as Draft' : 'Save Draft'; ?></button>
+                            <?php else: // Campaign is 'sent' ?>
+                                <a href="compose.php" class="btn btn-primary">Compose New Campaign</a>
+                                <!-- Or a "Clone Campaign" button could be here -->
+                            <?php endif; ?>
                         </div>
                     </div>
                 </div>
@@ -172,54 +315,41 @@ if (!isset($conn) || $conn === null) {
         const scheduleCheckbox = document.getElementById('schedule_send_checkbox');
         const scheduleOptionsDiv = document.getElementById('schedule_options');
         const campaignNameInput = document.getElementById('campaign_name');
-        const subjectInput = document.getElementById('subject');
-        const bodyHtmlTextarea = document.getElementById('body_html');
+        // const subjectInput = document.getElementById('subject'); // Not directly used in this version of JS
+        // const bodyHtmlTextarea = document.getElementById('body_html'); // Not directly used
 
-        if (templateSelect) {
+        // JS for template loading (primarily for new campaigns)
+        if (templateSelect && !templateSelect.disabled) { // Only add listener if not disabled (i.e. new or draft)
             templateSelect.addEventListener('change', function() {
                 const templateId = this.value;
-                const currentCampaignName = campaignNameInput.value;
-                const currentSubject = subjectInput.value;
-                const currentBody = bodyHtmlTextarea.value;
+                const currentCampaignName = campaignNameInput ? campaignNameInput.value : '';
+                // const currentSubject = subjectInput ? subjectInput.value : ''; // If needed to preserve
+                // const currentBody = bodyHtmlTextarea ? bodyHtmlTextarea.value : ''; // If needed to preserve
 
-                let params = new URLSearchParams();
+                let params = new URLSearchParams(window.location.search); // Preserve existing GET params like edit_campaign_id
+
                 if (templateId) {
-                    params.append('load_template_id', templateId);
-                }
-                // Preserve current form data in URL to repopulate after reload
-                if (currentCampaignName) params.append('campaign_name', currentCampaignName);
-                if (currentSubject && templateId) params.append('preserve_subject', currentSubject); // only preserve subject if loading new template
-                if (currentBody && templateId) params.append('preserve_body', currentBody); // only preserve body if loading new template
-
-
-                // If user selects "-- Select a Template --"
-                if (!templateId) {
-                    // Optionally, you might want to clear the subject and body if the user deselects a template
-                    // subjectInput.value = '';
-                    // bodyHtmlTextarea.value = '';
-                    // Or simply reload without load_template_id to reset to blank/POST state
-                    window.location.href = 'compose.php?' + params.toString();
-
+                    params.set('load_template_id', templateId); // Use .set to override if already there
                 } else {
-                     window.location.href = 'compose.php?' + params.toString();
+                    params.delete('load_template_id');
                 }
+                // To preserve other fields, get their current values and add to params
+                // For example, to preserve campaign name if user typed it then selected template:
+                if (currentCampaignName) {
+                    params.set('campaign_name_preserve', currentCampaignName);
+                }
+                // Add more fields to preserve if necessary
 
+                window.location.href = 'compose.php?' + params.toString();
             });
         }
 
-        // Repopulate form fields from URL parameters if they exist (after template load)
+        // Repopulate campaign_name if preserved in URL (e.g., after template load)
         const urlParams = new URLSearchParams(window.location.search);
-        if (urlParams.has('load_template_id')) { // Only do this if a template was just loaded
-            if (urlParams.has('campaign_name') && campaignNameInput.value === '') { // only if not already filled by PHP (e.g. POST error)
-                campaignNameInput.value = urlParams.get('campaign_name');
-            }
-             // Subject and Body are filled by PHP based on template_id
-             // However, if we had 'preserve_subject' or 'preserve_body', this means user typed something THEN changed template.
-             // PHP would have loaded template. If we want to override with what user typed before selecting template:
-            // if (urlParams.has('preserve_subject')) subjectInput.value = urlParams.get('preserve_subject');
-            // if (urlParams.has('preserve_body')) bodyHtmlTextarea.value = urlParams.get('preserve_body');
+        if (urlParams.has('campaign_name_preserve') && campaignNameInput && campaignNameInput.value === '') {
+            campaignNameInput.value = urlParams.get('campaign_name_preserve');
         }
-
+        // PHP should handle prefilling subject and body from template or DB, so JS might not need to.
 
         if (scheduleCheckbox) {
             scheduleCheckbox.addEventListener('change', function() {
@@ -229,6 +359,12 @@ if (!isset($conn) || $conn === null) {
                     scheduleOptionsDiv.style.display = 'none';
                 }
             });
+             // Initial state based on checkbox, important if page is reloaded with error or prefilled
+            if (scheduleCheckbox.checked) {
+                scheduleOptionsDiv.style.display = 'block';
+            } else {
+                scheduleOptionsDiv.style.display = 'none';
+            }
         }
     });
     </script>

--- a/dashboard.php
+++ b/dashboard.php
@@ -106,9 +106,9 @@ $recent_campaigns = get_recent_campaigns(5); // Get 5 recent campaigns
                                                 <td><?php echo $campaign['clicks_percentage']; ?></td>
                                                 <td>
                                                     <?php if (strtolower($campaign['status']) == 'draft' || strtolower($campaign['status']) == 'scheduled'): ?>
-                                                        <button class="btn btn-sm btn-outline-primary">Edit</button>
+                                                        <a href="compose.php?edit_campaign_id=<?php echo htmlspecialchars($campaign['id']); ?>" class="btn btn-sm btn-outline-primary">Edit</a>
                                                     <?php else: ?>
-                                                        <button class="btn btn-sm btn-outline-primary">View</button>
+                                                        <button class="btn btn-sm btn-outline-info">View</button> <?php // Remains a non-functional button for 'sent' status for now ?>
                                                     <?php endif; ?>
                                                 </td>
                                             </tr>

--- a/includes/compose_functions.php
+++ b/includes/compose_functions.php
@@ -4,14 +4,16 @@ if (basename(__FILE__) == basename($_SERVER["SCRIPT_FILENAME"])) {
     exit('No direct script access allowed');
 }
 
-require_once __DIR__ . '/../config/database.php'; // For $conn, if used directly, though better to pass
-require_once __DIR__ . '/templates_functions.php'; // For get_all_templates, get_template_by_id
-require_once __DIR__ . '/contacts_functions.php';   // For get_all_contacts (maybe later for recipient selection)
+// Note: config/database.php is included by includes/functions.php,
+// which should be included by any page using these compose functions.
+// So, $conn should be globally available.
+require_once __DIR__ . '/templates_functions.php';
+require_once __DIR__ . '/contacts_functions.php';
 
 // Function to get all templates for a dropdown
 if (!function_exists('get_all_templates_for_compose')) {
     function get_all_templates_for_compose($conn) {
-        return get_all_templates($conn); // Assumes get_all_templates returns id and name
+        return get_all_templates($conn);
     }
 }
 
@@ -26,54 +28,153 @@ if (!function_exists('get_template_content_for_compose')) {
     }
 }
 
-// Function to save a new campaign (draft, scheduled, etc.)
-// For now, recipient handling will be simplified (e.g., not linking to specific contacts table rows)
+// Function to save a new campaign or update an existing one
 if (!function_exists('save_campaign_to_db')) {
-    function save_campaign_to_db($conn, $campaign_name, $subject, $body_html, $status = 'draft', $scheduled_at = null) {
-        // Basic validation
+    function save_campaign_to_db($conn, $campaign_name, $subject, $body_html, $status = 'draft', $scheduled_at_input = null, $campaign_id_for_update = null) {
+
+        global $conn; // Ensure $conn is in scope
+
+        // Basic validation for core content (applies to both insert and update)
         if (empty($campaign_name) || empty($subject) || empty($body_html)) {
             return "Campaign name, subject, and body are required.";
         }
 
-        $sql = "INSERT INTO campaigns (name, subject, body_html, status, scheduled_at, created_at) VALUES (?, ?, ?, ?, ?, NOW())";
+        // Database connection check
+        if (!isset($conn) || !$conn instanceof mysqli || !$conn->ping()) {
+            error_log("save_campaign_to_db: Database connection is not valid.");
+            return "Database connection error.";
+        }
+
+        $scheduled_at_db_val = null;
+        $sent_at_sql_val = "NULL"; // Default SQL value for sent_at
+
+        // Prepare scheduled_at and sent_at based on status
+        if ($status === 'sent') {
+            $sent_at_sql_val = "NOW()"; // Use SQL NOW() for sent_at
+            $scheduled_at_db_val = null; // If sending now, it's not scheduled
+        } elseif ($status === 'scheduled') {
+            if (empty($scheduled_at_input)) {
+                return "Scheduled date/time is required for scheduled campaigns.";
+            }
+            try {
+                $date = new DateTime($scheduled_at_input);
+                $scheduled_at_db_val = $date->format('Y-m-d H:i:s');
+            } catch (Exception $e) {
+                error_log("Invalid scheduled date/time format: " . $scheduled_at_input . " Exception: " . $e->getMessage());
+                return "Invalid scheduled date/time format. Please use a valid date and time.";
+            }
+            // sent_at_sql_val remains "NULL"
+        } else { // 'draft' or other statuses
+            $status = 'draft'; // Ensure status defaults to 'draft' if not 'sent' or 'scheduled'
+            // scheduled_at_db_val remains null
+            // sent_at_sql_val remains "NULL"
+        }
+
+        if ($campaign_id_for_update && is_numeric($campaign_id_for_update)) {
+            // UPDATE Logic
+            // Assumes 'updated_at' column in DB schema has ON UPDATE CURRENT_TIMESTAMP
+            $sql = "UPDATE campaigns SET
+                        name = ?,
+                        subject = ?,
+                        body_html = ?,
+                        status = ?,
+                        scheduled_at = ?,
+                        sent_at = " . $sent_at_sql_val . "
+                    WHERE id = ?";
+
+            $stmt = $conn->prepare($sql);
+            if ($stmt === false) {
+                error_log("Prepare failed (UPDATE campaign): (" . $conn->errno . ") " . $conn->error . " SQL: " . $sql);
+                return "Database prepare error (update campaign).";
+            }
+            $stmt->bind_param("sssssi", $campaign_name, $subject, $body_html, $status, $scheduled_at_db_val, $campaign_id_for_update);
+
+            if ($stmt->execute()) {
+                $affected_rows = $stmt->affected_rows; // Check if any row was actually updated
+                $stmt->close();
+                // Even if no rows were changed (e.g. same data submitted), consider it a success if query executed.
+                // Or, you could return a specific message/code: return $affected_rows > 0 ? (int)$campaign_id_for_update : 'no_changes';
+                return (int)$campaign_id_for_update;
+            } else {
+                error_log("Execute failed (UPDATE campaign): (" . $stmt->errno . ") " . $stmt->error);
+                $error_detail = $stmt->error;
+                $stmt->close();
+                return "Failed to update campaign: " . $error_detail;
+            }
+
+        } else {
+            // INSERT Logic
+            // Assumes 'created_at' has DEFAULT CURRENT_TIMESTAMP or is set by NOW()
+            // Assumes 'updated_at' (if exists) has DEFAULT CURRENT_TIMESTAMP or ON UPDATE CURRENT_TIMESTAMP
+            $sql = "INSERT INTO campaigns (name, subject, body_html, status, scheduled_at, sent_at, created_at)
+                    VALUES (?, ?, ?, ?, ?, " . $sent_at_sql_val . ", NOW())";
+
+            $stmt = $conn->prepare($sql);
+            if ($stmt === false) {
+                error_log("Prepare failed (INSERT campaign): (" . $conn->errno . ") " . $conn->error . " SQL: " . $sql);
+                return "Database prepare error (insert campaign).";
+            }
+            $stmt->bind_param("sssss", $campaign_name, $subject, $body_html, $status, $scheduled_at_db_val);
+
+            if ($stmt->execute()) {
+                $new_campaign_id = $conn->insert_id;
+                $stmt->close();
+                return (int)$new_campaign_id; // Return new ID on successful insert
+            } else {
+                error_log("Execute failed (INSERT campaign): (" . $stmt->errno . ") " . $stmt->error);
+                $error_detail = $stmt->error;
+                $stmt->close();
+                return "Failed to save new campaign: " . $error_detail;
+            }
+        }
+    }
+}
+
+
+if (!function_exists('get_campaign_by_id')) {
+    /**
+     * Fetches a specific campaign by its ID.
+     *
+     * @param mysqli $conn The database connection object.
+     * @param int $campaign_id The ID of the campaign to fetch.
+     * @return array|null An associative array of the campaign data if found, otherwise null.
+     */
+    function get_campaign_by_id($conn, $campaign_id) {
+        global $conn; // Ensure $conn is in scope if not passed explicitly and relying on global from functions.php
+
+        if (!isset($conn) || !$conn instanceof mysqli || !$conn->ping()) { // Added ping() for active connection check
+            error_log("get_campaign_by_id: Database connection is not valid or not active.");
+            return null;
+        }
+        if (empty($campaign_id) || !is_numeric($campaign_id)) {
+            error_log("get_campaign_by_id: Invalid campaign_id provided: " . print_r($campaign_id, true));
+            return null;
+        }
+
+        $sql = "SELECT id, name, subject, body_html, status, scheduled_at FROM campaigns WHERE id = ?";
         $stmt = $conn->prepare($sql);
+
         if ($stmt === false) {
-            error_log("Prepare failed: (" . $conn->errno . ") " . $conn->error);
-            return "Database prepare error.";
+            error_log("Prepare failed for get_campaign_by_id: (" . $conn->errno . ") " . $conn->error);
+            return null;
         }
 
-        // For scheduled_at, if it's an empty string or not a valid date format, it should be NULL
-        $scheduled_at_db = null; // Default to NULL
-        if (!empty($scheduled_at)) {
-           // Attempt to create a DateTime object to validate and format
-           try {
-               // Check if it's already in Y-m-d H:i:s or Y-m-d H:i format from datetime-local input
-               if (preg_match('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?$/', $scheduled_at)) {
-                    $date = new DateTime($scheduled_at); // Handles 'YYYY-MM-DDTHH:MM'
-                    $scheduled_at_db = $date->format('Y-m-d H:i:s');
-               } elseif (strtotime($scheduled_at) !== false) { // More general validation
-                    $date = new DateTime($scheduled_at);
-                    $scheduled_at_db = $date->format('Y-m-d H:i:s');
-               } else {
-                    return "Invalid scheduled date/time format. Please use YYYY-MM-DD HH:MM or a valid date string.";
-               }
-           } catch (Exception $e) {
-               // Invalid date/time format provided
-               error_log("Scheduled_at parsing error: " . $e->getMessage() . " for input: " . $scheduled_at);
-               return "Invalid scheduled date/time format. Exception: " . $e->getMessage();
-           }
-        }
-
-        $stmt->bind_param("sssss", $campaign_name, $subject, $body_html, $status, $scheduled_at_db);
+        $stmt->bind_param("i", $campaign_id);
 
         if ($stmt->execute()) {
-            $stmt->close();
-            return true; // Success
+            $result = $stmt->get_result();
+            if ($result->num_rows === 1) {
+                $campaign = $result->fetch_assoc();
+                $stmt->close();
+                return $campaign;
+            } else {
+                $stmt->close();
+                return null; // Not found
+            }
         } else {
-            error_log("Execute failed: (" . $stmt->errno . ") " . $stmt->error);
-            $error_message = "Failed to save campaign: " . $stmt->error;
+            error_log("Execute failed for get_campaign_by_id: (" . $stmt->errno . ") " . $stmt->error);
             $stmt->close();
-            return $error_message;
+            return null;
         }
     }
 }

--- a/tools/run_scheduler_simulation.php
+++ b/tools/run_scheduler_simulation.php
@@ -1,0 +1,101 @@
+<?php
+// tools/run_scheduler_simulation.php
+// This script simulates a scheduler picking up due campaigns and marking them as sent.
+
+// Define ROOT_PATH if not already defined, to ensure includes work correctly.
+// This script is intended to be run from the project root directory like: php tools/run_scheduler_simulation.php
+if (!defined('ROOT_PATH')) {
+    // If run from project root as `php tools/run_scheduler_simulation.php`, __DIR__ is `project_root/tools`
+    // So ROOT_PATH should be dirname(__DIR__)
+    define('ROOT_PATH', dirname(__DIR__) . '/');
+}
+
+// Ensure config/database.php is loaded. This file should define $conn.
+if (file_exists(ROOT_PATH . 'config/database.php')) {
+    require_once ROOT_PATH . 'config/database.php';
+} else {
+    echo "Error: Database configuration file not found at " . ROOT_PATH . "config/database.php
+";
+    exit(1);
+}
+
+
+if (!isset($conn) || !$conn instanceof mysqli || !$conn->ping()) {
+    echo "Database connection error. Please check configuration (config/database.php).
+";
+    // Attempt to display mysqli connection error if $conn object exists but ping failed
+    if (isset($conn) && $conn instanceof mysqli) {
+        echo "MySQLi Connection Error: " . $conn->connect_error . "
+";
+    }
+    exit(1);
+}
+
+echo "Scheduler Simulation Started: " . date("Y-m-d H:i:s") . "
+";
+$processed_count = 0;
+$error_count = 0;
+
+// 1. Find due scheduled campaigns
+$sql_select = "SELECT id FROM campaigns WHERE status = 'scheduled' AND scheduled_at <= NOW()";
+$result = $conn->query($sql_select);
+
+if ($result === false) {
+    echo "Error querying for due campaigns: " . $conn->error . "
+";
+    $conn->close();
+    exit(1);
+}
+
+if ($result->num_rows === 0) {
+    echo "No scheduled campaigns are due to be sent at this time.
+";
+    $conn->close();
+    exit(0);
+}
+
+echo "Found " . $result->num_rows . " campaign(s) due for sending.
+";
+
+// 2. Prepare the update statement
+// Also update scheduled_at to NULL as it's no longer scheduled to be sent in the future
+$sql_update = "UPDATE campaigns SET status = 'sent', sent_at = NOW(), scheduled_at = NULL WHERE id = ?";
+$stmt_update = $conn->prepare($sql_update);
+
+if ($stmt_update === false) {
+    echo "Error preparing update statement: " . $conn->error . "
+";
+    $conn->close();
+    exit(1);
+}
+
+// 3. Loop and update
+while ($campaign = $result->fetch_assoc()) {
+    $campaign_id = $campaign['id'];
+
+    $stmt_update->bind_param("i", $campaign_id);
+    if ($stmt_update->execute()) {
+        echo "Campaign ID " . $campaign_id . " successfully updated to 'sent'.
+";
+        $processed_count++;
+    } else {
+        echo "Error updating campaign ID " . $campaign_id . ": " . $stmt_update->error . "
+";
+        $error_count++;
+    }
+}
+
+$stmt_update->close();
+$result->free(); // Free the result set
+$conn->close();
+
+echo "
+Scheduler Simulation Finished: " . date("Y-m-d H:i:s") . "
+";
+echo "Successfully processed: " . $processed_count . " campaign(s).
+";
+echo "Failed to process: " . $error_count . " campaign(s).
+";
+
+exit(0);
+?>


### PR DESCRIPTION
This commit introduces significant improvements to campaign handling:

1.  **Campaign Composition (`compose.php`):**
    *   **UI Enhancements:**
        *   Added a "Send Immediately" button.
        *   Renamed "Schedule Campaign" to "Save and Schedule".
        *   Improved button order and spacing.
    *   **Edit Functionality:**
        *   Campaigns can now be loaded for editing via `compose.php?edit_campaign_id=<ID>`.
        *   The form is pre-filled with the existing campaign's data (name, subject, body, schedule details).
        *   A hidden `campaign_id` field is used for update operations.
        *   Page title and UI cues (e.g., read-only fields for sent campaigns, adjusted button text) dynamically change when in edit mode.
    *   **POST Handling:**
        *   Logic now correctly distinguishes between creating new campaigns and updating existing ones.
        *   Handles new `'send_now'` action, setting status to `'sent'`.
        *   Success messages are more descriptive (e.g., "created," "updated," "sent," "scheduled") and include the campaign ID.
        *   After a successful update, campaign data is reloaded to refresh UI elements if staying on the page.

2.  **Backend (`includes/compose_functions.php`):**
    *   **`save_campaign_to_db()`:**
        *   Now handles both `INSERT` (new) and `UPDATE` (existing) campaign operations.
        *   Correctly sets `status`, `scheduled_at`, and `sent_at` (using `NOW()` for immediate sends) based on the chosen action for both inserts and updates. This includes nullifying `scheduled_at` if sent immediately, or `sent_at` if scheduled/drafted.
        *   Returns the campaign ID (new or existing) on success, or an error string on failure.
        *   Uses prepared statements and binds status correctly for security.
    *   **`get_campaign_by_id()`:**
        *   New function to fetch campaign details for editing.

3.  **Dashboard (`dashboard.php`):**
    *   "Edit" links for 'draft' and 'scheduled' campaigns in the "Recent Campaigns" table now correctly point to `compose.php?edit_campaign_id=<ID>`.

4.  **Scheduler Simulation (`tools/run_scheduler_simulation.php`):**
    *   (Optional) Added a manual script to find due scheduled campaigns, update their status to 'sent', set `sent_at = NOW()`, and `scheduled_at = NULL`. This aids in understanding the campaign lifecycle.

These changes provide more robust control over creating, editing, scheduling, and immediately sending campaigns, significantly improving the core campaign management workflow.